### PR TITLE
Match graph font size with document text size

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -24,7 +24,7 @@
 		// Matches a XML opening `svg` tag with "width" and "height" attributes
 		// in this order, and captures the width and the height in pt.
 		let svg-width-height-regex = regex(
-			`<svg\s+`.text
+			`<svg\s`.text
 			+ xml-attributes-regex
 			+ width-attribute-regex
 			+ xml-attributes-regex
@@ -34,7 +34,7 @@
 		)
 		// Same, but with "width" and "height" in reverse order.
 		let svg-height-width-regex = regex(
-			`<svg\s+`.text
+			`<svg\s`.text
 			+ xml-attributes-regex
 			+ width-attribute-regex
 			+ xml-attributes-regex

--- a/lib.typ
+++ b/lib.typ
@@ -72,12 +72,13 @@
 		)
 	}
 
+	let initial-dimensions = get-svg-dimensions(render)
+	let svg-text-size = 14pt // Default font size in Graphviz
 	style(styles => {
-		let initial-dimensions = get-svg-dimensions(render)
-
-		let svg-text-size = 14pt // Default font size in Graphviz
 		let document-text-size = measure(line(length: 1em), styles).width
-		let (auto-width, auto-height) = initial-dimensions.map(dimension => dimension / svg-text-size * document-text-size)
+		let (auto-width, auto-height) = initial-dimensions.map(dimension => {
+			dimension / svg-text-size * document-text-size
+		})
 
 		let final-width = if width == auto { auto-width } else { width }
 		let final-height = if height == auto { auto-height } else { height }

--- a/lib.typ
+++ b/lib.typ
@@ -16,11 +16,11 @@
 	let get-svg-dimensions(svg) = {
 		// Matches an arbitrary amount of arbitrary XML attributes with a
 		// double-quoted values.
-		let xml-attributes-regex = `(?:(?:(?:\w|-)+=".+?[^\\]"|\s*)*?)`.text
+		let xml-attributes-regex = `(?:(?:[\w-]+=".+?[^\\]"|\s*)*?)`.text
 		// Matches a "width" XML attribute and captures its value.
-		let width-attribute-regex = `(?:width="((?:\d|.)+(?:pt|cm))")`.text
+		let width-attribute-regex = `(?:width="([\d.]+(?:pt|cm))")`.text
 		// Same for height.
-		let height-attribute-regex = `(?:height="((?:\d|.)+(?:pt|cm))")`.text
+		let height-attribute-regex = `(?:height="([\d.]+(?:pt|cm))")`.text
 		// Matches a XML opening `svg` tag with "width" and "height" attributes
 		// in this order, and captures the width and the height in pt.
 		let svg-width-height-regex = regex(

--- a/lib.typ
+++ b/lib.typ
@@ -32,7 +32,7 @@
 	let get-svg-dimensions(svg) = {
 		// Matches an arbitrary amount of arbitrary XML attributes with a
 		// double-quoted values.
-		let xml-attributes-regex = `(?:(?:[\w-]+=".+?[^\\]"|\s*)*?)`.text
+		let xml-attributes-regex = `(?:[\w-]+=".+?[^\\]"|\s*)*?`.text
 		// Matches a "width" XML attribute and captures its value.
 		let width-attribute-regex = `(?:width="([\d.]+)pt")`.text
 		// Same for height.

--- a/lib.typ
+++ b/lib.typ
@@ -3,24 +3,93 @@
 #let render(text, engine: "dot", width: auto, height: auto, fit: "contain", background: "transparent") = {
 	let render = str(
 		plugin.render(
-			bytes(text), 
-			bytes(engine), 
+			bytes(text),
+			bytes(engine),
 			bytes(background)
 		)
 	)
 
+	/// Returns a `(width, height)` pair corresponding to the dimensions of an
+	/// SVG, which is passed as its source code.
+	///
+	/// If the dimensions of the SVG cannot be inferred, returns `none`.
+	let get-svg-dimensions(svg) = {
+		// Matches an arbitrary amount of arbitrary xml attributes with a
+		// double-quoted values.
+		let xml-attributes-regex = `(?:(?:\w|-)+=".+?[^\\]"|\s*)*?`.text
+		// Matches a "width" xml attribute and captures its value.
+		let width-attribute-regex = `(?:width="(\d+(?:pt|cm))")`.text
+		// Same for height.
+		let height-attribute-regex = `(?:height="(\d+(?:pt|cm))")`.text
+		// Matches a xml opening `svg` tag with "width" and "height" attributes
+		// in this order, and captures the width and the height in pt.
+		let svg-width-height-regex = regex(
+			`<svg\s+`.text
+			+ xml-attributes-regex
+			+ width-attribute-regex
+			+ xml-attributes-regex
+			+ height-attribute-regex
+			+ xml-attributes-regex
+			+ ">"
+		)
+		// Same, but with "width" and "height" in reverse order.
+		let svg-height-width-regex = regex(
+			`<svg\s+`.text
+			+ xml-attributes-regex
+			+ width-attribute-regex
+			+ xml-attributes-regex
+			+ height-attribute-regex
+			+ xml-attributes-regex
+			+ ">"
+		)
+
+		let result
+		let match = svg.match(svg-width-height-regex)
+		if match != none {
+			result = match.captures
+		} else {
+			let match = svg.match(svg-height-width-regex)
+			if match != none {
+				result = match.captures
+			} else {
+				return none
+			}
+		}
+		result.map(eval)
+	}
 
 	if render.slice(0, 6) == "error:" {
 		return raw(render)
-	} else {
+	}
+
+	if width != auto and height != auto {
 		return image.decode(
 			render,
 			format: "svg",
-			height: height,
 			width: width,
+			height: height,
 			fit: fit,
 		)
 	}
+
+	style(styles => {
+		let initial-dimensions = get-svg-dimensions(render)
+
+		let svg-text-size = 14pt // Default font size in Graphviz
+		let document-text-size = measure(line(length: 1em), styles).width
+		let (auto-width, auto-height) = initial-dimensions.map(dimension => dimension / svg-text-size * document-text-size)
+
+		let final-width = if width == auto { auto-width } else { width }
+		let final-height = if height == auto { auto-height } else { height }
+
+		return image.decode(
+			render,
+			format: "svg",
+			width: final-width,
+			height: final-height,
+			fit: fit,
+		)
+	})
 }
 
 #let raw-render(engine: "dot", width: auto, height: auto, fit: "contain", background: "transparent", raw) = {

--- a/lib.typ
+++ b/lib.typ
@@ -14,14 +14,14 @@
 	///
 	/// If the dimensions of the SVG cannot be inferred, returns `none`.
 	let get-svg-dimensions(svg) = {
-		// Matches an arbitrary amount of arbitrary xml attributes with a
+		// Matches an arbitrary amount of arbitrary XML attributes with a
 		// double-quoted values.
 		let xml-attributes-regex = `(?:(?:\w|-)+=".+?[^\\]"|\s*)*?`.text
-		// Matches a "width" xml attribute and captures its value.
+		// Matches a "width" XML attribute and captures its value.
 		let width-attribute-regex = `(?:width="(\d+(?:pt|cm))")`.text
 		// Same for height.
 		let height-attribute-regex = `(?:height="(\d+(?:pt|cm))")`.text
-		// Matches a xml opening `svg` tag with "width" and "height" attributes
+		// Matches a XML opening `svg` tag with "width" and "height" attributes
 		// in this order, and captures the width and the height in pt.
 		let svg-width-height-regex = regex(
 			`<svg\s+`.text

--- a/lib.typ
+++ b/lib.typ
@@ -9,55 +9,6 @@
 		)
 	)
 
-	/// Returns a `(width, height)` pair corresponding to the dimensions of an
-	/// SVG, which is passed as its source code.
-	///
-	/// If the dimensions of the SVG cannot be inferred, returns `none`.
-	let get-svg-dimensions(svg) = {
-		// Matches an arbitrary amount of arbitrary XML attributes with a
-		// double-quoted values.
-		let xml-attributes-regex = `(?:(?:[\w-]+=".+?[^\\]"|\s*)*?)`.text
-		// Matches a "width" XML attribute and captures its value.
-		let width-attribute-regex = `(?:width="([\d.]+pt)")`.text
-		// Same for height.
-		let height-attribute-regex = `(?:height="([\d.]+pt)")`.text
-		// Matches a XML opening `svg` tag with "width" and "height" attributes
-		// in this order, and captures the width and the height in pt.
-		let svg-width-height-regex = regex(
-			`<svg\s`.text
-			+ xml-attributes-regex
-			+ width-attribute-regex
-			+ xml-attributes-regex
-			+ height-attribute-regex
-			+ xml-attributes-regex
-			+ ">"
-		)
-		// Same, but with "width" and "height" in reverse order.
-		let svg-height-width-regex = regex(
-			`<svg\s`.text
-			+ xml-attributes-regex
-			+ width-attribute-regex
-			+ xml-attributes-regex
-			+ height-attribute-regex
-			+ xml-attributes-regex
-			+ ">"
-		)
-
-		let result
-		let match = svg.match(svg-width-height-regex)
-		if match != none {
-			result = match.captures
-		} else {
-			let match = svg.match(svg-height-width-regex)
-			if match != none {
-				result = match.captures
-			} else {
-				return none
-			}
-		}
-		result.map(x => float(x) * 1pt)
-	}
-
 	if render.slice(0, 6) == "error:" {
 		return raw(render)
 	}
@@ -72,6 +23,52 @@
 
 	if width != auto and height != auto {
 		return default
+	}
+
+	/// Returns a `(width, height)` pair corresponding to the dimensions of an
+	/// SVG, which is passed as its source code.
+	///
+	/// If the dimensions of the SVG cannot be inferred, returns `none`.
+	let get-svg-dimensions(svg) = {
+		// Matches an arbitrary amount of arbitrary XML attributes with a
+		// double-quoted values.
+		let xml-attributes-regex = `(?:(?:[\w-]+=".+?[^\\]"|\s*)*?)`.text
+		// Matches a "width" XML attribute and captures its value.
+		let width-attribute-regex = `(?:width="([\d.]+)pt")`.text
+		// Same for height.
+		let height-attribute-regex = `(?:height="([\d.]+)pt")`.text
+		// Matches a XML opening `svg` tag with a "width" attribute, and its
+		// value in pt.
+		let svg-width-regex = regex(
+			`<svg\s`.text
+			+ xml-attributes-regex
+			+ width-attribute-regex
+			+ xml-attributes-regex
+			+ ">"
+		)
+		// Matches a XML opening `svg` tag with a "height" attribute, and its
+		// value in pt.
+		let svg-height-regex = regex(
+			`<svg\s`.text
+			+ xml-attributes-regex
+			+ height-attribute-regex
+			+ xml-attributes-regex
+			+ ">"
+		)
+
+		let width-match = svg.match(svg-width-regex)
+		if width-match == none {
+			return none
+		}
+		let width = float(width-match.captures.first()) * 1pt
+
+		let height-match = svg.match(svg-height-regex)
+		if height-match == none {
+			return none
+		}
+		let height = float(height-match.captures.first()) * 1pt
+
+		(width, height)
 	}
 
 	let initial-dimensions = get-svg-dimensions(render)

--- a/lib.typ
+++ b/lib.typ
@@ -16,11 +16,11 @@
 	let get-svg-dimensions(svg) = {
 		// Matches an arbitrary amount of arbitrary XML attributes with a
 		// double-quoted values.
-		let xml-attributes-regex = `(?:(?:\w|-)+=".+?[^\\]"|\s*)*?`.text
+		let xml-attributes-regex = `(?:(?:(?:\w|-)+=".+?[^\\]"|\s*)*?)`.text
 		// Matches a "width" XML attribute and captures its value.
-		let width-attribute-regex = `(?:width="(\d+(?:pt|cm))")`.text
+		let width-attribute-regex = `(?:width="((?:\d|.)+(?:pt|cm))")`.text
 		// Same for height.
-		let height-attribute-regex = `(?:height="(\d+(?:pt|cm))")`.text
+		let height-attribute-regex = `(?:height="((?:\d|.)+(?:pt|cm))")`.text
 		// Matches a XML opening `svg` tag with "width" and "height" attributes
 		// in this order, and captures the width and the height in pt.
 		let svg-width-height-regex = regex(

--- a/lib.typ
+++ b/lib.typ
@@ -62,17 +62,24 @@
 		return raw(render)
 	}
 
+	let default = image.decode(
+		render,
+		format: "svg",
+		width: width,
+		height: height,
+		fit: fit,
+	)
+
 	if width != auto and height != auto {
-		return image.decode(
-			render,
-			format: "svg",
-			width: width,
-			height: height,
-			fit: fit,
-		)
+		return default
 	}
 
 	let initial-dimensions = get-svg-dimensions(render)
+
+	if initial-dimensions == none {
+		return default
+	}
+
 	let svg-text-size = 14pt // Default font size in Graphviz
 	style(styles => {
 		let document-text-size = measure(line(length: 1em), styles).width

--- a/lib.typ
+++ b/lib.typ
@@ -18,9 +18,9 @@
 		// double-quoted values.
 		let xml-attributes-regex = `(?:(?:[\w-]+=".+?[^\\]"|\s*)*?)`.text
 		// Matches a "width" XML attribute and captures its value.
-		let width-attribute-regex = `(?:width="([\d.]+(?:pt|cm))")`.text
+		let width-attribute-regex = `(?:width="([\d.]+pt)")`.text
 		// Same for height.
-		let height-attribute-regex = `(?:height="([\d.]+(?:pt|cm))")`.text
+		let height-attribute-regex = `(?:height="([\d.]+pt)")`.text
 		// Matches a XML opening `svg` tag with "width" and "height" attributes
 		// in this order, and captures the width and the height in pt.
 		let svg-width-height-regex = regex(
@@ -55,7 +55,7 @@
 				return none
 			}
 		}
-		result.map(eval)
+		result.map(x => float(x) * 1pt)
 	}
 
 	if render.slice(0, 6) == "error:" {


### PR DESCRIPTION
By default, Diagraph generates images with dimensions set to `auto`. This means the image will occupy as much space as possible. Instead, the default should be to match the font size within the graph to the current font size in the document. This is what this PR achieves.

### How it works

The idea is quite simple: the generated SVG (see below) file already declares its dimensions in pt, we just need to read them and use those as the default dimensions, instead of `auto`.

```svg
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<!-- Generated by graphviz version 9.0.0 (20230911.1827)
-->
<!-- Pages: 1 -->
<svg width="242pt" height="44pt"
viewBox="0.00 0.00 242.00 44.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
…
</svg>
```

We use two regular expressions to match the opening `svg` XML tag and capture the values of the "width" and "height" attributes. Here is the general idea:
```regex
<svg{arbitrary XML attributes}{width,height}="([\d.]+)pt"{arbitrary XML attributes}>
```
where `{arbitrary XML attributes}` is
```regex
(?:[\w-]+=".+?[^\\]"|\s*)*?
```

Great! We now know the dimensions of the generated SVG, so we can simply use them for the dimensions of the [`image`](https://typst.app/docs/reference/visualize/image/). Though, we still have a slight problem: the document font size might not match the SVG font size. We know that Graphviz uses 14pt as the default font size, so we just need to get the current text size to know by how much to scale the image. Until get rules are implemented in Typst (see https://laurmaedje.github.io/posts/types-and-context/), we can do that with
```typ
#let document-text-size = measure(line(length: 1em), styles).width
```

### Concerns

There are two major concerns with this approach.

#### Regular expressions are bad

First, regular expressions were not made to parse things that way. They are inefficient, and might break. For example, you might have noticed earlier that the regular expression that I claimed parses arbitrary XML attributes does not work in some cases. For example, `attribute="value\\"` is not recognized, because there is a `\` before the closing quote. This kind of problem is not really possible to fix with regular expressions alone.

However, it is important to note that the input of our regular expressions is generated by a computer, and, as such, very likely to always "look the same." This means if they worked in some cases, they will likely work in most (if not all) future cases.

#### Performance

Another problem with this implementation is performance. I decided to do all this parsing stuff in Typst instead of C because it is easier to work with, and ensures memory safety. This implies that compiling documents with a large number of graphs might significantly degrade performances (though I have not conducted any benchmark).

Although this is a valid concern, I do not think it is too problematic. First, Typst uses memoization, so the regex work should only happen once per graph if the user uses `typst watch`. Moreover, explicitely specifying the width and height with `render(…, width: …, height: …)` (which had to be done before anyways for graph not to be too big) prevents the expensive computations from ever happening.
