### PR TITLE
Fix missaligned graphs

### DIFF
--- a/internals.typ
+++ b/internals.typ
@@ -229,7 +229,8 @@
       let ratio = final-width / svg-width
       final-height = svg-height * ratio
     }
-	
+
+    set align(top + left)
 
 		// Rescale the final image to the desired size.
 		show: block.with(


### PR DESCRIPTION
Previously, we assumed `top + left` alignment. We now force `align(top + left)` when generating the graph, which fixes #17.