### PR TITLE
Interpret escape sequences in labels properly

### DIFF
--- a/internals.typ
+++ b/internals.typ
@@ -73,6 +73,39 @@
   })
 }
 
+/// Converts a string containing escape sequences to content.
+#let parse-string(s) = {
+  let result = []
+  let row = ""
+  let is-escaped = false
+
+  for cluster in s {
+    if is-escaped {
+      is-escaped = false
+
+      if cluster == "l" {
+        result += align(left, row)
+        row = ""
+      } else if cluster == "n" {
+        result += align(center, row)
+        row = ""
+      } else if cluster == "r" {
+        result += align(right, row)
+        row = ""
+      } else {
+        row += cluster
+      }
+    } else if cluster == "\\" {
+      is-escaped = true
+    } else {
+      row += cluster
+    }
+  }
+
+  set block(spacing: 0.65em)
+  result + align(center, row)
+}
+
 /// Get an array of evaluated labels from a graph.
 #let get-labels(manual-label-names, dot) = {
   let encoded-labels = plugin.get_labels(
@@ -85,7 +118,7 @@
     let mode = str(encoded-label.slice(0, 1))
     let label-str = str(encoded-label.slice(1))
     if mode == "t" {
-      [#label-str]
+      parse-string(label-str)
     } else if mode == "m" {
       math.equation(eval(mode: "math", label-str))
     } else {


### PR DESCRIPTION
Fixes one of the two problems mentioned in #20.

Escape sequences `\l`, `\n` and `\r` can now be used to create lines and align them.

For example,

```dot
digraph G {
	{
		one [
			label = "First\rhey\rtest\nSecond\"\nh\le\v\m",
			color = "#BF101D",
			fontcolor = "#BF101D"
		];
		two [
			label = "Third\nFourth",
			color = "#BF101D",
			fontcolor = "#BF101D"
		];
	}
	one -> two [
		color = "#BF101D",
		penwidth = 2,
	];
}
```

generates the following graph with Diagraph:

![Labels are aligned properly.](https://github.com/Robotechnic/diagraph/assets/57839069/3a95f12b-0c4b-4c52-b2e5-dd895ee9ffb8)

For comparison, Edotor generates the following graph:

![image](https://github.com/Robotechnic/diagraph/assets/57839069/4d8e3a54-33be-4a0b-8fe7-7e4850fe8595)
