### PR TITLE
Make it possible to align graphs other than top + left

### DIFF
--- a/internals.typ
+++ b/internals.typ
@@ -230,15 +230,17 @@
       final-height = svg-height * ratio
     }
 
-    set align(top + left)
-
 		// Rescale the final image to the desired size.
+
 		show: block.with(
       width: final-width,
       height: final-height,
       clip: clip,
       breakable: false,
     )
+
+    set align(top + left)
+
 		show: scale.with(
       origin: top + left,
       x: final-width / svg-width * 100%,


### PR DESCRIPTION
#18 made it impossible to align graphs other than `top + left`. This PR makes it possible to align graphs any way, like it was before #18 (while keeping the fix for #17).